### PR TITLE
mandatory pull before v1.3 release

### DIFF
--- a/TinyLog.Mvc/TinyLogHandleErrorAttribute.cs
+++ b/TinyLog.Mvc/TinyLogHandleErrorAttribute.cs
@@ -60,7 +60,7 @@ namespace TinyLog.Mvc
             filterContext.Result = vr;
 
             bool handled = true;
-            if (!LogCrawlers && !IsBot(filterContext.HttpContext))
+            if (LogCrawlers || (!LogCrawlers && !filterContext.HttpContext.Request.Browser.Crawler && !IsBot(filterContext.HttpContext)))
             {
                 handled = TinyLog.Log.Default.WriteLogEntry<ActionFilterCustomData>(entry, ActionFilterCustomData.FromExceptionContext(filterContext));
             }


### PR DESCRIPTION
choice of logging crawlers and bots generating HTTP 500 errors implemented in TinyLogHandleErrorAttribute
